### PR TITLE
Enhance OrderDetailTab to display decoration comments line by line an…

### DIFF
--- a/horaservices/src/components/OrderDetailTab/index.jsx
+++ b/horaservices/src/components/OrderDetailTab/index.jsx
@@ -880,25 +880,27 @@ orderId={orderDetail?.order_id}
                   </div>
 
                   {/* Additional Comments */}
-                  <div>
+                <div>
                     <div className="fw-semiBold myOrderDetails-heading">
                       Additional Comments
                     </div>
                     {decorationComments && (
-                      <div className="info-row">
-                        <div className="info-icon">
+                    <div>
+                    {decorationComments.split('\n').map((comment, index) => (
+                       <div key={index} className="info-row">
+                          <div className="info-icon">
                           <Image
-                            src={checkIcon}
-                            alt="Info"
-                            className="info-icon-img"
-                          />
-                        </div>
+                           src={checkIcon}
+                           alt="Info"
+                           className="info-icon-img"
+                           />
+                          </div>
 
-                        <div>
-                          {decorationComments}
-                        </div>
+                       <div>{comment}</div>
                       </div>
-                    )}
+                    ))}
+                  </div>
+                )}
                   </div>
 
                   <div className="fw-semiBold myOrderDetails-heading">
@@ -1072,19 +1074,27 @@ orderId={orderDetail?.order_id}
                   {/* ================= ADDITIONAL COMMENTS ================= */}
                   <div className="fw-semiBold myOrderDetails-heading">
                     Additional Comments
-                  </div>
+                  </div> 
+                  
+                  {orderDetail.decoration_comments && (
+                    <div>
+                    {orderDetail.decoration_comments.split('\n').map((comment, index) => (
+                       <div key={index} className="info-row">
+                          <div className="info-icon">
+                          <Image
+                           src={checkIcon}
+                           alt="Info"
+                           width={13}
+                           height={13}
+                           style={{ marginRight: 8 }}
+                           />
+                          </div>
 
-                  <div className="info-row">
-                    <Image
-                      src={checkIcon}
-                      alt=""
-                      width={13}
-                      height={13}
-                      style={{ marginRight: 8 }}
-                    />
-                    <div>{orderDetail.decoration_comments || "N/A"}</div>
+                       <div>{comment}</div>
+                      </div>
+                    ))}
                   </div>
-
+                )}
 
                   {/* ================= PRICE DETAILS ================= */}
                   <div className="fw-semiBold myOrderDetails-heading">

--- a/horaservices/src/utils/apiconstants.js
+++ b/horaservices/src/utils/apiconstants.js
@@ -63,3 +63,4 @@ export const CREATE_DIRECT_CHAT_ROOM = "/api/customer/event/chat/create-direct-r
 export const SUBSCRIBE_NOTIFICATION = "/api/customer/event/chat/subscribe";
 export const UNSUBSCRIBE_NOTIFICATION = "/api/customer/event/chat/unsubscribe";
 export const UNREAD_MESSAGE_COUNT = "/api/customer/event/chat/chatrooms";
+export const GET_PHOTOGRAPHY_ORDER_DETAILS = "/api/order/order_details_photography";


### PR DESCRIPTION
1. add the photography api end point the api constant for call teh detail api of photography order 
2. fix the commet
<img width="673" height="865" alt="Screenshot 2026-03-21 at 6 02 41 PM" src="https://github.com/user-attachments/assets/c45d85f7-d192-4596-a238-11605e5727fc" />
<img width="590" height="823" alt="Screenshot 2026-03-21 at 6 02 57 PM" src="https://github.com/user-attachments/assets/9afd4e8d-6670-460d-a46a-0673d17cac86" />
photograpy and decoration page for new commnets